### PR TITLE
Redirecting from account page

### DIFF
--- a/app/makers_bnb.rb
+++ b/app/makers_bnb.rb
@@ -27,7 +27,10 @@ class MakersBnb < Sinatra::Base
     redirect '/users/new'
   end
 
-  get '/edit/:space_id'do
+  get '/edit/:space_id' do
+    unless current_user
+      redirect '/sessions/new'
+    end
     @space = Space.get(params[:space_id])
     if current_user.id == @space.user_id
       erb :'spaces/edit'
@@ -62,8 +65,12 @@ class MakersBnb < Sinatra::Base
   end
 
   get '/users/account' do
-    @users_spaces = Space.all(user_id: current_user.id)
-    erb :'users/account'
+    if current_user
+      @users_spaces = Space.all(user_id: current_user.id)
+      erb :'users/account'
+    else
+      redirect '/sessions/new'
+    end
   end
 
   get '/sessions/new' do

--- a/app/views/_sign_out.erb
+++ b/app/views/_sign_out.erb
@@ -6,6 +6,11 @@
     <ul class="nav navbar-nav navbar-right">
       <% if current_user %>
       <li>
+        <form action='/users/account'>
+          <button type='submit' formaction='/users/account' class="btn nav-btn">Account</button>
+        </form>
+      </li>
+      <li>
         <form action='/spaces/new'>
           <button type='submit' formaction='/spaces/new' class="btn nav-btn">List a Space</button>
         </form>

--- a/spec/features/editing_spaces_spec.rb
+++ b/spec/features/editing_spaces_spec.rb
@@ -9,6 +9,12 @@ feature 'Editing spaces' do
     Space.first.id
   end
 
+  scenario "can't edit spaces when not signed in"do
+    click_button 'Sign Out'
+    visit "/edit/#{space}"
+    expect(current_path).to eq "/sessions/new"
+  end
+
   scenario "can't edit spaces you don't own"do
     click_button 'Sign Out'
     sign_up(email: 'seconduser@email.com', username: 'seconduser')
@@ -17,7 +23,7 @@ feature 'Editing spaces' do
   end
 
   scenario 'space name can be editied after created' do
-    visit '/users/account'
+    click_button 'Account'
     expect(page).to have_content 'A beautiful relaxing space'
     first(".list").click_link("space")
     fill_in :name, with: 'My updated space'
@@ -27,7 +33,7 @@ feature 'Editing spaces' do
   end
 
   scenario 'space name can be editied after created' do
-    visit '/users/account'
+    click_button 'Account'
     expect(page).to have_content 'It is yellow'
     first(".list").click_link("space")
     fill_in :description, with: 'Oh!'
@@ -37,7 +43,7 @@ feature 'Editing spaces' do
   end
 
   scenario 'space name can be editied after created' do
-    visit '/users/account'
+    click_button 'Account'
     expect(page).to have_content '£5 per night'
     first(".list").click_link("space")
     fill_in :price, with: '10000'

--- a/spec/features/user_account_page_spec.rb
+++ b/spec/features/user_account_page_spec.rb
@@ -7,9 +7,15 @@ feature 'User account' do
   end
 
   scenario "shows spaces you own on account page" do
-    visit '/users/account'
+    click_button 'Account'
     expect(page).to have_content 'A beautiful relaxing space'
     expect(page).not_to have_content 'A terrible space'
+  end
+
+  scenario "redirects you to sign in page if not signed in" do
+    click_button 'Sign Out'
+    visit '/users/account'
+    expect(current_path).to eq '/sessions/new'
   end
 
 end


### PR DESCRIPTION
- Added 'Account' button: shows when logged in to navigate to account
- Cannot access route 'users/account' if not signed in (redirects to sign-in)
- Reformatted tests to include new 'Account' button
